### PR TITLE
Use digitalPinToInterrupt for interrupt pin mapping

### DIFF
--- a/MagStripe.cpp
+++ b/MagStripe.cpp
@@ -62,15 +62,15 @@ void MagStripe::begin(unsigned char track)
     pinMode(this->pin_cls, INPUT);
 
     // Reading is more reliable when using interrupts...
-    attachInterrupt(0, handle_data, CHANGE);    // data pin
-    attachInterrupt(1, handle_clock, FALLING);  // clock pin
+    attachInterrupt(digitalPinToInterrupt(MAGSTRIPE_RDT), handle_data, CHANGE);    // data pin
+    attachInterrupt(digitalPinToInterrupt(MAGSTRIPE_RCL), handle_clock, FALLING);  // clock pin
 }
 
 
 void MagStripe::stop()
 {
-    detachInterrupt(0);
-    detachInterrupt(1);
+    detachInterrupt(digitalPinToInterrupt(MAGSTRIPE_RDT));
+    detachInterrupt(digitalPinToInterrupt(MAGSTRIPE_RCL));
 }
 
 


### PR DESCRIPTION
Hello :)

As now recommended in the [Arduino `attachInterrupt` doc](https://www.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/), this PR suggests to use `digitalPinToInterrupt` to map a pin number to an interrupt number.

Allows to use the defined pin values for both pin mode setup and interrupt setup.